### PR TITLE
Fix missing repoid for rhrazdil_devel_kubic_libcontainers_stable

### DIFF
--- a/rhrazdil_devel_kubic_libcontainers_stable.repo
+++ b/rhrazdil_devel_kubic_libcontainers_stable.repo
@@ -1,3 +1,4 @@
+[rhrazdil_devel_kubic_libcontainers_stable]
 name=Stable Releases of Upstream github.com/containers packages (CentOS_8_Stream)
 type=rpm-md
 baseurl=https://rhrazdil.github.io/crio-mirror/devel_kubic_libcontainers_stable/


### PR DESCRIPTION
rhrazdil_devel_kubic_libcontainers_stable is missing repoid